### PR TITLE
Not using ioutil.ReadAll to parse JSON HTTP bodies

### DIFF
--- a/handlers/json.go
+++ b/handlers/json.go
@@ -2,19 +2,14 @@ package handlers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 )
 
 func JsonRequestToData(w http.ResponseWriter, r *http.Request) (
 	data map[string]interface{}, err error) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return data, err
-	}
 	// unmarshall to blank interface
 	var idata interface{}
-	err = json.Unmarshal(body, &idata)
+	err = json.NewDecoder(r.Body).Decode(&idata)
 	// type assertion to map
 	data = idata.(map[string]interface{})
 	return data, err
@@ -22,10 +17,5 @@ func JsonRequestToData(w http.ResponseWriter, r *http.Request) (
 
 func JsonRequestToType(w http.ResponseWriter, r *http.Request,
 	data interface{}) (err error) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal(body, &data)
-	return err
+	return json.NewDecoder(r.Body).Decode(&data)
 }


### PR DESCRIPTION
Hi :-) I thought you would like the small optimization that uses less memory when parsing the JSON data from the HTTP body. Since it doesn't use ioutil.ReadAll, there's no intermediate buffer, so it uses less resources.
