### PR TITLE
Remove return to make clippy happy

### DIFF
--- a/pickup-rust/src/index.rs
+++ b/pickup-rust/src/index.rs
@@ -5,7 +5,7 @@ use crate::{app_state::AppState, player::Command};
 
 #[get("/")]
 pub async fn hello() -> impl Responder {
-    return HttpResponse::Ok().body("Hello");
+    HttpResponse::Ok().body("Hello")
 }
 
 #[post("/play")]
@@ -15,14 +15,14 @@ pub async fn play(data: web::Data<AppState>) -> impl Responder {
         file: String::from(mp3_file),
     }) as Box<dyn Command>;
     let _ = data.sender.send(command);
-    return HttpResponse::Ok().body("ok");
+    HttpResponse::Ok().body("ok")
 }
 
 #[post("/stop")]
 pub async fn stop(data: web::Data<AppState>) -> impl Responder {
     let command = Box::new(StopCommand {}) as Box<dyn Command>;
     let _ = data.sender.send(command);
-    return HttpResponse::Ok().body("ok");
+    HttpResponse::Ok().body("ok")
 }
 
 #[post("/volume/{volume}")]
@@ -31,5 +31,5 @@ pub async fn volume(data: web::Data<AppState>, volume: web::Path<f32>) -> impl R
         volume: volume.into_inner(),
     }) as Box<dyn Command>;
     let _ = data.sender.send(command);
-    return HttpResponse::Ok().body("ok");
+    HttpResponse::Ok().body("ok")
 }


### PR DESCRIPTION
Clippy wants us to use a statement for implicit return, and who am I to
argue?

- Remove return and trailing semicolon
