### PR TITLE
[Build] Parallelize rust test and build

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -7,30 +7,34 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-#   - name: Use Node.js ${{ matrix.node-version }}
-#     uses: actions/setup-node@v1
-#     with:
-#        node-version: 15.x
-#    - run: make react
-
     - name: install libraries
       run: sudo apt-get install libasound2-dev
-
     - uses: Swatinem/rust-cache@v1
       with:
         working-directory: pickup-rust
-
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
     - run: cd pickup-rust && cargo fmt -- --check
     - run: cd pickup-rust && cargo clippy -- -Dwarnings
     - run: cd pickup-rust && cargo test
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install libraries
+      run: sudo apt-get install libasound2-dev
+    - uses: Swatinem/rust-cache@v1
+      with:
+        working-directory: pickup-rust
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
     - run: cd pickup-rust && cargo build --release
 
 # TODO cross-compiling https://github.com/marketplace/actions/rust-cargo#cross-compilation


### PR DESCRIPTION
Split fmt/clippy/test (debug builds) from build (release) to improve caching. It looks like with this setup the caching of .target/ leads to a significant speedup, plus these two flows can run in parallel.
    
In testing we see a change from 8 mins to 1 min, but this may be distorted by having a 'hot' actions host, we may not see this for infrequent builds.