### PR TITLE
[Actions] setup-go v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
         node-version: 16.x
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.16.x
     # We don't have it setup in the Makefile to avoid double-building, but 'make lint'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16.x
+        go-version: 1.19.x
     # We don't have it setup in the Makefile to avoid double-building, but 'make lint'
     # requires the react build to have completed.
     - run: make react


### PR DESCRIPTION
- Update actions/setup-go action to v3
- Use go 1.19 in CI, latest version
