### PR TITLE
[CI] Rust cache paths

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+defaults:
+  run:
+    shell: bash
+    working-directory: pickup-rust
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,30 +18,46 @@ jobs:
     - uses: actions/checkout@v3
     - name: install libraries
       run: sudo apt-get install libasound2-dev
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v3
       with:
-        workspaces: |
-          - pickup-rust
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - run: cd pickup-rust && cargo fmt -- --check
-    - run: cd pickup-rust && cargo clippy --no-deps -- -Dwarnings
-    - run: cd pickup-rust && cargo test
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          pickup-rust/target/
+        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+    - name: Update rust toolchain
+      run: |
+        rustup update
+        rustup component add clippy
+    - name: 'Check format'
+      run: cargo fmt -- --check
+    - name: 'Run clippy linter'
+      run: cargo clippy --no-deps -- -Dwarnings
+    - name: 'Run tests'
+      run: cargo test
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: install libraries
       run: sudo apt-get install libasound2-dev
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v3
       with:
-        workspaces: |
-          - pickup-rust
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - run: cd pickup-rust && cargo build --release
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          pickup-rust/target/
+        key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+    - name: Update rust toolchain
+      run: |
+        rustup update
+        rustup component add clippy
+    - name: 'Build release binary'
+      run: cargo build --release
 
 # TODO cross-compiling https://github.com/marketplace/actions/rust-cargo#cross-compilation
 # Might not be possible if we have platform-specific dependencies


### PR DESCRIPTION
[CI] Drop rust-toolchain and rust-cache actions
    
The actions-rs/toolchain action is poorly maintained, and it looks like it might not be needed.
    
The rust-cache action was somehow calculating a different key to save the cache than the one it used to restore, so there was never a cache hit. Not sure why. Switching to the plain `actions/cache` seems to fix the problem (build time from 6min to under 1min).
    
Also, set the working-directory for all steps as a default.