### PR TITLE
[Rust] Refactor cache and collection a little

### DIFF
--- a/pickup-rust/src/filemanager/collection.rs
+++ b/pickup-rust/src/filemanager/collection.rs
@@ -1,4 +1,4 @@
-use super::{model::Track, utils::generate_id};
+use super::{cache, model::Track, options::CollectionOptions, utils::generate_id};
 use crate::filemanager::model::Category;
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -13,6 +13,11 @@ const CATEGORY_PREFIX: &str = "_";
 const CD_REGEX_STR: &str = r"(?i)(cd|dis(c|k)) ?\d";
 
 pub type Collection = HashMap<String, Category>;
+
+pub fn init(options: CollectionOptions) -> std::io::Result<Collection> {
+    let files = cache::init(options)?;
+    Ok(build(files))
+}
 
 struct CollectionBuilder {
     collection: Collection,

--- a/pickup-rust/src/filemanager/list.rs
+++ b/pickup-rust/src/filemanager/list.rs
@@ -1,9 +1,12 @@
-use crate::filemanager::cache::{self, CacheOptions};
+use crate::filemanager::collection::init;
 
-use super::model::{Album, Artist, Category};
+use super::{
+    model::{Album, Artist, Category},
+    options::CollectionOptions,
+};
 
-pub fn list(cache_options: CacheOptions) -> std::io::Result<()> {
-    let collection = cache::init(cache_options).unwrap();
+pub fn list(cache_options: CollectionOptions) -> std::io::Result<()> {
+    let collection = init(cache_options).unwrap();
     log::info!("We have got {} categories", collection.len());
 
     for (category_name, category) in collection {

--- a/pickup-rust/src/filemanager/mod.rs
+++ b/pickup-rust/src/filemanager/mod.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod collection;
 pub mod list;
 pub mod model;
+pub mod options;
 pub mod utils;
 
 // I compared using walkdir to just using fs to visit every dir and it is

--- a/pickup-rust/src/filemanager/options.rs
+++ b/pickup-rust/src/filemanager/options.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug)]
+pub struct CollectionOptions {
+    pub dir: String,
+    pub ignores: Option<Vec<String>>,
+}


### PR DESCRIPTION
- Make 'cache' be unaware of 'collection' - it just deals in plain paths.
- Move main 'init()' to 'collection'.
- Rename 'CacheOptions' to 'CollectionOptions'
