### PR TITLE
[Rust] Refactor into lib.rs for integration tests

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -34,8 +34,8 @@ jobs:
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v3
       with:
-        name: pickup-rust (Linux, AMD64)
-        path: pickup-rust/target/release/pickup-rust
+        name: pickup (Rust, Linux, AMD64)
+        path: pickup-rust/target/release/pickup
 
 # TODO cross-compiling https://github.com/marketplace/actions/rust-cargo#cross-compilation
 # Might not be possible if we have platform-specific dependencies

--- a/pickup-rust/Cargo.lock
+++ b/pickup-rust/Cargo.lock
@@ -1279,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pickup-rust"
+name = "pickup"
 version = "0.1.0"
 dependencies = [
  "actix-web",

--- a/pickup-rust/Cargo.toml
+++ b/pickup-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pickup-rust"
+name = "pickup"
 version = "0.1.0"
 authors = ["Andy O'Neill <andy@potatoriot.com>"]
 edition = "2021"

--- a/pickup-rust/src/filemanager/cache.rs
+++ b/pickup-rust/src/filemanager/cache.rs
@@ -3,6 +3,7 @@ use std::collections::{hash_map::DefaultHasher, HashSet};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
+
 use walkdir::WalkDir;
 
 use super::options::CollectionOptions;

--- a/pickup-rust/src/filemanager/collection.rs
+++ b/pickup-rust/src/filemanager/collection.rs
@@ -1,12 +1,13 @@
-use super::{cache, model::Track, options::CollectionOptions, utils::generate_id};
-use crate::filemanager::model::Category;
-use lazy_static::lazy_static;
-use regex::Regex;
 use std::{
     borrow::Cow,
     collections::{HashMap, VecDeque},
     path::PathBuf,
 };
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use super::{cache, model::Category, model::Track, options::CollectionOptions, utils::generate_id};
 
 const DEFAULT_CATEGORY: &str = "Music";
 const CATEGORY_PREFIX: &str = "_";
@@ -177,8 +178,8 @@ mod tests {
 
     #[test]
     fn test_is_category() {
-        assert_eq!(true, is_category(Some(&Cow::from("_Trance"))));
-        assert_eq!(false, is_category(Some(&Cow::from("Smashing Pumpkins"))));
+        assert!(is_category(Some(&Cow::from("_Trance"))));
+        assert!(!is_category(Some(&Cow::from("Smashing Pumpkins"))));
     }
 
     #[test]
@@ -187,10 +188,10 @@ mod tests {
         let non_disc_strings = vec!["C D1", "thing 1", "An Album", "Album Part 2", "CD II"];
 
         for test_string in disc_strings {
-            assert_eq!(true, is_disc(Some(&Cow::from(test_string))));
+            assert!(is_disc(Some(&Cow::from(test_string))));
         }
         for test_string in non_disc_strings {
-            assert_eq!(false, is_disc(Some(&Cow::from(test_string))));
+            assert!(!is_disc(Some(&Cow::from(test_string))));
         }
     }
 

--- a/pickup-rust/src/filemanager/list.rs
+++ b/pickup-rust/src/filemanager/list.rs
@@ -5,8 +5,8 @@ use super::{
     options::CollectionOptions,
 };
 
-pub fn list(cache_options: CollectionOptions) -> std::io::Result<()> {
-    let collection = init(cache_options).unwrap();
+pub fn list(collection_options: CollectionOptions) -> std::io::Result<()> {
+    let collection = init(collection_options).unwrap();
     log::info!("We have got {} categories", collection.len());
 
     for (category_name, category) in collection {

--- a/pickup-rust/src/filemanager/mod.rs
+++ b/pickup-rust/src/filemanager/mod.rs
@@ -4,6 +4,3 @@ pub mod list;
 pub mod model;
 pub mod options;
 pub mod utils;
-
-// I compared using walkdir to just using fs to visit every dir and it is
-// significantly faster on the network drive.

--- a/pickup-rust/src/lib.rs
+++ b/pickup-rust/src/lib.rs
@@ -1,0 +1,72 @@
+pub mod api;
+pub mod app_state;
+pub mod filemanager;
+pub mod player;
+
+use std::sync::mpsc;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::thread;
+
+use actix_web::middleware::Logger;
+use actix_web::web::Data;
+use actix_web::{App, HttpServer};
+
+use app_state::AppState;
+use filemanager::collection;
+use filemanager::options::CollectionOptions;
+use player::{Command, Player};
+
+// Enable assert_matches in tests
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
+
+#[derive(Clone)]
+pub struct ServeOptions {
+    pub collection_options: CollectionOptions,
+    pub port: u32,
+}
+
+pub async fn serve(options: ServeOptions) -> std::io::Result<()> {
+    let sender = spawn_player();
+    let collection = collection::init(options.collection_options.clone()).unwrap();
+    let collection_arc = Arc::new(collection);
+
+    let address = format!("0.0.0.0:{}", options.port);
+    log::info!("Starting on http://{}", address);
+    HttpServer::new(move || {
+        App::new()
+            .app_data(Data::new(AppState {
+                // Note - we have to call .clone() within this `move` block so that each worker gets it's own clone of
+                // the channel.
+                // https://docs.rs/actix-web/4.0.1/actix_web/struct.App.html#shared-mutable-state
+                sender: sender.clone(),
+                collection: collection_arc.clone(),
+            }))
+            .wrap(Logger::default())
+            .service(api::hello)
+            .service(api::control::play)
+            .service(api::control::stop)
+            .service(api::control::volume)
+            .service(api::list::list_categories)
+    })
+    .workers(2)
+    .bind(address.as_str())?
+    .shutdown_timeout(60) // <- Set shutdown timeout to 60 seconds
+    .run()
+    .await
+}
+
+fn spawn_player() -> Sender<Box<dyn Command>> {
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let mut player = Player::new();
+
+        for command in rx {
+            player.command(command);
+        }
+    });
+    tx
+}

--- a/pickup-rust/src/main.rs
+++ b/pickup-rust/src/main.rs
@@ -1,31 +1,14 @@
-use actix_web::middleware::Logger;
-use actix_web::web::Data;
-use actix_web::{App, HttpServer};
-use clap::Parser;
-use std::sync::mpsc;
-use std::sync::mpsc::Sender;
-use std::thread;
-use std::{io::Write, sync::Arc};
-
-mod api;
-mod app_state;
 mod cli;
-mod filemanager;
-mod player;
 
-use app_state::AppState;
-use cli::{Cli, Commands};
+use std::io::Write;
+
+use clap::Parser;
 use env_logger::Env;
-use filemanager::options::CollectionOptions;
-use filemanager::{cache, list::list};
-use player::{Command, Player};
 
-use crate::filemanager::collection;
-
-// Enable assert_matches in tests
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
+use cli::{Cli, Commands};
+use pickup::filemanager::options::CollectionOptions;
+use pickup::filemanager::{cache, list::list};
+use pickup::{serve, ServeOptions};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -38,71 +21,23 @@ async fn main() -> std::io::Result<()> {
 
     let music_dir: &str = cli.music_dir.as_str();
 
-    let cache_options = CollectionOptions {
+    let collection_options = CollectionOptions {
         dir: music_dir.to_string(),
         ignores: None,
     };
 
     match cli.command {
-        Commands::List {} => list(cache_options),
+        Commands::List {} => list(collection_options),
         Commands::Refresh {} => {
-            let result = cache::refresh(cache_options.clone());
+            let result = cache::refresh(collection_options.clone());
             result.map(|_| ())
         }
         Commands::Serve { port } => {
             serve(ServeOptions {
-                cache_options: cache_options.clone(),
+                collection_options: collection_options.clone(),
                 port,
             })
             .await
         }
     }
-}
-
-struct ServeOptions {
-    cache_options: CollectionOptions,
-    port: u32,
-}
-
-async fn serve(options: ServeOptions) -> std::io::Result<()> {
-    let sender = spawn_player();
-    let collection = collection::init(options.cache_options.clone()).unwrap();
-    let collection_arc = Arc::new(collection);
-
-    let address = format!("0.0.0.0:{}", options.port);
-    log::info!("Starting on http://{}", address);
-    HttpServer::new(move || {
-        App::new()
-            .app_data(Data::new(AppState {
-                // Note - we have to call .clone() within this `move` block so that each worker gets it's own clone of
-                // the channel.
-                // https://docs.rs/actix-web/4.0.1/actix_web/struct.App.html#shared-mutable-state
-                sender: sender.clone(),
-                collection: collection_arc.clone(),
-            }))
-            .wrap(Logger::default())
-            .service(api::hello)
-            .service(api::control::play)
-            .service(api::control::stop)
-            .service(api::control::volume)
-            .service(api::list::list_categories)
-    })
-    .workers(2)
-    .bind(address.as_str())?
-    .shutdown_timeout(60) // <- Set shutdown timeout to 60 seconds
-    .run()
-    .await
-}
-
-fn spawn_player() -> Sender<Box<dyn Command>> {
-    let (tx, rx) = mpsc::channel();
-
-    thread::spawn(move || {
-        let mut player = Player::new();
-
-        for command in rx {
-            player.command(command);
-        }
-    });
-    tx
 }

--- a/pickup-rust/src/player/mod.rs
+++ b/pickup-rust/src/player/mod.rs
@@ -15,6 +15,12 @@ pub struct Player {
     sink: Sink,
 }
 
+impl Default for Player {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Player {
     pub fn new() -> Player {
         log::info!("Creating stream and sink");

--- a/pickup-rust/tests/filemanager.rs
+++ b/pickup-rust/tests/filemanager.rs
@@ -1,0 +1,27 @@
+use ::assert_matches::assert_matches;
+use pickup::filemanager::{
+    cache::{init, refresh},
+    options::CollectionOptions,
+};
+
+const NUM_FILES: usize = 6;
+
+#[test]
+fn test_refresh_and_load() {
+    let options = CollectionOptions {
+        dir: String::from("../music"),
+        ignores: None,
+    };
+
+    let result = refresh(options.clone());
+
+    assert_matches!(result, Ok(_));
+    let files = result.unwrap();
+    assert_eq!(NUM_FILES, files.len());
+
+    let load_result = init(options);
+
+    assert_matches!(load_result, Ok(_));
+    let loaded_files = load_result.unwrap();
+    assert_eq!(files, loaded_files);
+}


### PR DESCRIPTION
I want to write some integration tests to make sure e.g. the filemanager module is basically working properly. In order to expose internal APIs to integration tests, we need to take a 'binary plus library' approach, i.e. add lib.rs and make main.rs be a small wrapper around it.

- Refactor into lib.rs and main.rs
- Rename crate to 'pickup'
- Organize imports (manually, I don't know how to automate that)
- Address some clippy complaints about `assert_eq!(true, blah);`
- Add a first integration test
