### PR TITLE
[API] Add first E2E test

### DIFF
--- a/pickup-rust/Cargo.lock
+++ b/pickup-rust/Cargo.lock
@@ -605,6 +605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1287,12 +1302,14 @@ dependencies = [
  "bincode",
  "clap",
  "env_logger",
+ "itertools",
  "lazy_static",
  "log",
  "rand",
  "regex",
  "rodio",
  "serde",
+ "serde_json",
  "sled",
  "walkdir",
 ]
@@ -1516,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",

--- a/pickup-rust/Cargo.toml
+++ b/pickup-rust/Cargo.toml
@@ -15,10 +15,12 @@ log = "^0"
 rodio = "^0"
 sled = "^0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.89"
 walkdir = "2"
 rand = "0.8.5"
 regex = "1.6.0"
 lazy_static = "1.4.0"
+itertools = "0.10.5"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/pickup-rust/src/api/list.rs
+++ b/pickup-rust/src/api/list.rs
@@ -1,4 +1,5 @@
 use actix_web::{get, web, Responder, Result};
+use itertools::sorted;
 use lazy_static::__Deref;
 use serde::Serialize;
 
@@ -18,11 +19,12 @@ struct ListCategoriesResponse {
 pub async fn list_categories(data: web::Data<AppState>) -> Result<impl Responder> {
     let collection = data.collection.deref();
     let mut api_categories: Vec<ApiCategory> = vec![];
-    for category in collection.values() {
+
+    sorted(collection.keys()).for_each(|category| {
         api_categories.push(ApiCategory {
-            name: category.name.clone(),
+            name: collection.get(category).unwrap().name.clone(),
         })
-    }
+    });
     let response = ListCategoriesResponse {
         categories: api_categories,
     };

--- a/pickup-rust/src/app_state.rs
+++ b/pickup-rust/src/app_state.rs
@@ -2,6 +2,7 @@ use std::sync::{mpsc::Sender, Arc};
 
 use crate::{filemanager::collection::Collection, player::Command};
 
+#[derive(Clone)]
 pub struct AppState {
     pub sender: Sender<Box<dyn Command>>,
     pub collection: Arc<Collection>,

--- a/pickup-rust/src/filemanager/collection.rs
+++ b/pickup-rust/src/filemanager/collection.rs
@@ -44,7 +44,7 @@ impl CollectionBuilder {
     }
 
     fn add_track(&mut self, track: Track) {
-        log::info!("Adding track {:?}", track.path);
+        log::info!("Adding track [{:?}] {:?}", track.category, track.path);
         let category = self.add_category(track.category.clone());
         match (&track.artist, &track.album) {
             (Some(artist_name), Some(album_name)) => {

--- a/pickup-rust/tests/helpers.rs
+++ b/pickup-rust/tests/helpers.rs
@@ -1,0 +1,27 @@
+use actix_web::{
+    body::MessageBody,
+    dev::{ServiceFactory, ServiceRequest, ServiceResponse},
+    App, Error,
+};
+use pickup::{build_app, build_app_state, filemanager::options::CollectionOptions, ServeOptions};
+
+pub fn build_test_app() -> App<
+    impl ServiceFactory<
+        ServiceRequest,
+        Response = ServiceResponse<impl MessageBody>,
+        Config = (),
+        InitError = (),
+        Error = Error,
+    >,
+> {
+    let options = ServeOptions {
+        collection_options: CollectionOptions {
+            dir: String::from("../music"),
+            ignores: None,
+        },
+        port: 3001,
+    };
+
+    let app_state = build_app_state(&options);
+    return build_app(app_state);
+}

--- a/pickup-rust/tests/index_e2e.rs
+++ b/pickup-rust/tests/index_e2e.rs
@@ -1,0 +1,15 @@
+use actix_web::test;
+
+use crate::helpers::build_test_app;
+
+mod helpers;
+
+#[actix_web::test]
+async fn test_index_get() {
+    let app = test::init_service(build_test_app()).await;
+    let req = test::TestRequest::get().uri("/").to_request();
+
+    let resp = test::call_and_read_body(&app, req).await;
+
+    assert_eq!(&resp[..], b"Hello");
+}

--- a/pickup-rust/tests/list_e2e.rs
+++ b/pickup-rust/tests/list_e2e.rs
@@ -1,0 +1,19 @@
+use actix_web::test;
+
+mod helpers;
+
+use helpers::build_test_app;
+use serde_json::{self, json};
+
+#[actix_web::test]
+async fn test_list_categories() {
+    let app = test::init_service(build_test_app()).await;
+    let req = test::TestRequest::get().uri("/categories").to_request();
+
+    let resp: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+
+    assert_eq!(
+        resp,
+        json!({ "categories": [{"name": "Music"}, {"name": "Free"}] })
+    );
+}


### PR DESCRIPTION
- Refactor app setup and build test helper to get a test app instance.
- Add E2E tests for index and list collections endpoints.
- Fix a problem where collections list was not consistently sorted (might want to revisit and use BTreeMap for that).

Note: I spent a lot of time battling actix for this, trying to figure out how to return a test app. The type that `test::init_service()` returns is not usable, it references types from private crates inside Actix. I don't mind the solution I ended up with but I'd like the flexibility to create the ergonomics I want for test code.
