### PR TITLE
[Rust] Find a valid track in the collection in /play

### DIFF
--- a/pickup-rust/src/api/control.rs
+++ b/pickup-rust/src/api/control.rs
@@ -5,10 +5,27 @@ use crate::{app_state::AppState, player::Command};
 
 #[post("/play")]
 pub async fn play(data: web::Data<AppState>) -> impl Responder {
-    let mp3_file = "../music/Kevin MacLeod/Album 1/01 - Lukewarm Banjo.mp3";
-    let command = Box::new(PlayCommand {
-        file: String::from(mp3_file),
-    }) as Box<dyn Command>;
+    // TODO for now let's just look for the first track, it seems to work on our demo music
+    let track = data
+        .collection
+        .values()
+        .next()
+        .unwrap()
+        .artists
+        .values()
+        .next()
+        .unwrap()
+        .albums
+        .values()
+        .next()
+        .unwrap()
+        .tracks
+        .first()
+        .unwrap();
+    // TODO shouldn't the path be absolute or relative already? Or maybe the Player needs to know the prefix
+    let path = format!("../music/{}", track.path.as_os_str().to_str().unwrap());
+
+    let command = Box::new(PlayCommand { file: path }) as Box<dyn Command>;
     let _ = data.sender.send(command);
     HttpResponse::Ok().body("ok")
 }


### PR DESCRIPTION
In the /play control endpoint, we had a hard-coded track that has been moved, so the (proof of concept) endpoint was failing. We can fix that by using the collection to find a track (albeit in a pretty fragile manner!). It's still PoC.
