### PR TITLE
[cargo] Update shlex dependency because of CVE

### DIFF
--- a/pickup-rust/Cargo.lock
+++ b/pickup-rust/Cargo.lock
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"


### PR DESCRIPTION
Shell quoting issues in shlex, fixed in v1.3
