### PR TITLE
[Rust] Replace lazy_static with LazyLock

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1603,7 +1603,6 @@ dependencies = [
  "clap",
  "env_logger",
  "factori",
- "lazy_static",
  "log",
  "once_cell",
  "rand",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -20,7 +20,6 @@ serde_json = "^1"
 walkdir = "^2"
 rand = "^0"
 regex = "^1"
-lazy_static = "^1"
 once_cell = "^1"
 rkyv = "^0.8"
 

--- a/rs/src/api/list.rs
+++ b/rs/src/api/list.rs
@@ -1,5 +1,4 @@
 use actix_web::{get, web, Responder, Result};
-use lazy_static::__Deref;
 use serde::Serialize;
 
 use crate::app_state::AppState;
@@ -40,7 +39,7 @@ struct ListCategoriesResponse {
 
 #[get("/categories")]
 pub async fn list_categories(data: web::Data<AppState>) -> Result<impl Responder> {
-    let collection = data.collection.deref();
+    let collection = data.collection.as_ref();
 
     let api_categories: Vec<ApiCategory> = collection
         .values()

--- a/rs/src/filemanager/collection_builder.rs
+++ b/rs/src/filemanager/collection_builder.rs
@@ -1,6 +1,5 @@
-use std::{borrow::Cow, collections::VecDeque, path::PathBuf};
+use std::{borrow::Cow, collections::VecDeque, path::PathBuf, sync::LazyLock};
 
-use lazy_static::lazy_static;
 use regex::Regex;
 
 use super::{
@@ -12,6 +11,8 @@ use super::{
 const DEFAULT_CATEGORY: &str = "Music";
 const CATEGORY_PREFIX: &str = "_";
 const CD_REGEX_STR: &str = r"(?i)(cd|dis(c|k)) ?\d";
+
+static CD_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(CD_REGEX_STR).unwrap());
 
 pub fn build(files: Vec<PathBuf>) -> Collection {
     let mut builder = CollectionBuilder::new();
@@ -129,9 +130,6 @@ fn to_track(path: &PathBuf) -> Result<Track, String> {
 }
 
 fn is_disc(dir: Option<&Cow<str>>) -> bool {
-    lazy_static! {
-        static ref CD_REGEX: Regex = Regex::new(CD_REGEX_STR).unwrap();
-    }
     dir.is_some() && CD_REGEX.is_match(dir.unwrap())
 }
 


### PR DESCRIPTION
The lazy_static crate is no longer required, the functionality for
static constructors is now built-in with LazyLock.

- Replace our one usage with LazyLock, and pull it out to a module-level constant.
- Replace .deref() with .as_ref(), which means we don't need the import in list.rs
