### PR TITLE
[Rust] Clamp volume, implement retrieve volume

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -14,7 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: install libraries
-        run: sudo apt-get install libasound2-dev
+        run: sudo apt-get install libasound2-dev pulseaudio
+      # Plain ALSA fails in CI since there's no real device.
+      # I copied the pulseaudio trick from pulseaudio-rs CI config.
+      # https://github.com/colinmarc/pulseaudio-rs/blob/main/.github/workflows/tests.yaml
+      - name: Setup pulseaudio
+        run: |
+          systemctl --user enable pulseaudio
+          systemctl --user start pulseaudio
+          pactl load-module module-null-sink sink_name=test_sink
+          pactl set-default-sink test_sink
       - uses: actions/cache@v6
         with:
           path: |

--- a/rs/src/api/control.rs
+++ b/rs/src/api/control.rs
@@ -1,9 +1,11 @@
-use actix_web::{post, web, HttpResponse, Responder};
+use std::sync::mpsc::Sender;
+
+use actix_web::{get, post, web, HttpResponse, Responder};
 
 use crate::{app_state::AppState, player::Command};
 use crate::{
     filemanager::model::Track,
-    player::commands::{PlayCommand, StopCommand, VolumeCommand},
+    player::commands::{GetVolumeCommand, PlayCommand, StopCommand, VolumeCommand},
 };
 
 fn get_first_track(app_state: &AppState) -> &Track {
@@ -46,10 +48,38 @@ pub async fn stop(data: web::Data<AppState>) -> impl Responder {
 }
 
 #[post("/volume/{volume}")]
-pub async fn volume(data: web::Data<AppState>, volume: web::Path<f32>) -> impl Responder {
+pub async fn volume(data: web::Data<AppState>, volume: web::Path<u8>) -> impl Responder {
+    let clamped_volume = volume.into_inner().clamp(0, 100);
     let command = Box::new(VolumeCommand {
-        volume: volume.into_inner(),
+        volume: clamped_volume,
     }) as Box<dyn Command>;
     let _ = data.player_sender.send(command);
-    HttpResponse::Ok().body("ok")
+
+    let new_volume = _get_volume(data.player_sender.clone()).await;
+    HttpResponse::Ok().json(serde_json::json!({ "volume": new_volume }))
+}
+
+/**
+ * This demonstrates how to get info out of the Player thread. We create a
+ * short-lived channel pair and pass the sender into the player thread then
+ * wait for a response. The whole thing is wrapped in web::block() since it's
+ * synchronous code that will block until it receives a response.
+ */
+#[get("/volume")]
+pub async fn get_volume(data: web::Data<AppState>) -> impl Responder {
+    let data = data.clone();
+    let current_volume = _get_volume(data.player_sender.clone()).await;
+    HttpResponse::Ok().json(serde_json::json!({ "volume": current_volume }))
+}
+
+async fn _get_volume(player_sender: Sender<Box<dyn Command>>) -> u8 {
+    let current_volume = web::block(move || {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let command = Box::new(GetVolumeCommand { reply: tx }) as Box<dyn Command>;
+        let _ = player_sender.send(command);
+        rx.recv().unwrap()
+    })
+    .await
+    .unwrap_or(0);
+    current_volume
 }

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -72,6 +72,7 @@ pub fn build_app(
         .service(api::control::play)
         .service(api::control::stop)
         .service(api::control::volume)
+        .service(api::control::get_volume)
         .service(api::list::list_categories)
         .service(api::queue::add)
         .service(api::queue::clear)

--- a/rs/src/player/commands.rs
+++ b/rs/src/player/commands.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc::Sender;
+
 use crate::player::{Command, Player};
 
 pub struct PlayCommand {
@@ -19,11 +21,27 @@ impl Command for StopCommand {
 }
 
 pub struct VolumeCommand {
-    pub volume: f32,
+    pub volume: u8,
 }
 
 impl Command for VolumeCommand {
     fn action(&mut self, player: &mut Player) {
         player.set_volume(self.volume);
+    }
+}
+
+/**
+ * Current pattern for a command that sends a response: pass a channel Sender
+ * over in the Command. This has a fair amount of boilerplate in the API call
+ * site.
+ */
+pub struct GetVolumeCommand {
+    pub reply: Sender<u8>,
+}
+
+impl Command for GetVolumeCommand {
+    fn action(&mut self, player: &mut Player) {
+        let volume = player.get_volume();
+        let _ = self.reply.send(volume);
     }
 }

--- a/rs/src/player/mod.rs
+++ b/rs/src/player/mod.rs
@@ -65,12 +65,32 @@ impl Player {
         self.player.stop();
     }
 
-    pub fn set_volume(&mut self, value: f32) {
-        self.player.set_volume(value);
+    pub fn set_volume(&mut self, value: u8) {
+        let float_volume = scale_volume_down(value);
+        log::info!("Setting volume to {}", float_volume);
+        self.player.set_volume(float_volume);
+    }
+
+    pub fn get_volume(&mut self) -> u8 {
+        let float_volume = self.player.volume();
+        log::info!("Current volume is {}", float_volume);
+        scale_volume_up(float_volume)
     }
 
     // This getter really only exists to silence the unused warning about sink.
     pub fn sink(&self) -> &MixerDeviceSink {
         &self.sink
     }
+}
+
+// scale down volume from 0-100 to 0-1.0
+fn scale_volume_down(volume_percentage: u8) -> f32 {
+    let clamped_volume = volume_percentage.clamp(0, 100);
+    clamped_volume as f32 / 100.0
+}
+
+fn scale_volume_up(vol_fraction: f32) -> u8 {
+    let percent_volume = (vol_fraction * 100.0).round();
+    let clamped_volume = percent_volume.clamp(0.0, 100.0);
+    clamped_volume as u8
 }

--- a/rs/tests/control_e2e.rs
+++ b/rs/tests/control_e2e.rs
@@ -1,0 +1,81 @@
+use actix_web::{test, web::Data};
+
+use assert_matches::assert_matches;
+use serial_test::serial;
+
+mod helpers;
+
+use helpers::build_test_app_state;
+use once_cell::sync::Lazy;
+use pickup::{
+    app_state::AppState,
+    build_app,
+    filemanager::{cache::refresh, options::CollectionOptions},
+};
+use serde_json::{self, json};
+
+// Share one app state (and its single Player thread) across every control test,
+// because a fresh Player opens a new audio sink and the volume value we read back
+// must persist between the set/get round-trips below.
+static APP_STATE: Lazy<Data<AppState>> = Lazy::new(build_test_app_state);
+
+async fn set_volume(value: u8) -> serde_json::Value {
+    let app = test::init_service(build_app((*APP_STATE).clone())).await;
+    let req = test::TestRequest::post()
+        .uri(format!("/volume/{}", value).as_str())
+        .to_request();
+    test::call_and_read_body_json(&app, req).await
+}
+
+#[serial(queue)]
+#[actix_web::test]
+async fn test_stop() {
+    let app = test::init_service(build_app((*APP_STATE).clone())).await;
+    let req = test::TestRequest::post().uri("/stop").to_request();
+
+    let resp = test::call_and_read_body(&app, req).await;
+
+    assert_eq!(&resp[..], b"ok");
+}
+
+#[serial(queue)]
+#[actix_web::test]
+async fn test_play() {
+    let options = CollectionOptions {
+        dir: String::from("../music"),
+        ignores: None,
+    };
+
+    let result = refresh(options.clone());
+
+    assert_matches!(result, Ok(_));
+    let app = test::init_service(build_app((*APP_STATE).clone())).await;
+    let req = test::TestRequest::post().uri("/play").to_request();
+
+    let resp = test::call_and_read_body(&app, req).await;
+
+    assert_eq!(&resp[..], b"ok");
+}
+
+#[serial(queue)]
+#[actix_web::test]
+async fn test_set_volume() {
+    // The POST handler sets the volume and reads it back, so the response
+    // echoes the value we just set.
+    let resp = set_volume(50).await;
+    assert_eq!(resp, json!({ "volume": 50 }));
+}
+
+#[serial(queue)]
+#[actix_web::test]
+async fn test_get_volume() {
+    // Set a known value through the POST endpoint, then read it back through GET.
+    let set = set_volume(30).await;
+    assert_eq!(set, json!({ "volume": 30 }));
+
+    let app = test::init_service(build_app((*APP_STATE).clone())).await;
+    let req = test::TestRequest::get().uri("/volume").to_request();
+
+    let resp: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+    assert_eq!(resp, json!({ "volume": 30 }));
+}


### PR DESCRIPTION
An AI review pointed out that the values of the volume input were not validated, so I dug in a bit there.

- Switch to using 0-100 for the volume in the API, and add a clamp as validation.
- Internally convert 0-100 to 0-1.0 for rodio
- Add a GetVolume command and `GET /volume` API. Currently implemented with a lot of boilerplate - we create a channel, pass the sender to the Player thread in the command, and then block until we get a response. I have some ideas on tidying this up a little.
- Add some initial e2e tests for control.rs
- Set up pulseaudio in CI to avoid device-not-found errors from ALSA
